### PR TITLE
Add GEOPLATFORM_URL setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ Then activate it in your `udata.cfg`:
 ```python
 PLUGINS = ['geoplatform']
 ```
+
+## Configuration
+
+You can control this plugin’s behavior with the following `udata.cfg` parameters:
+
+- **`GEOPLATFORM_URL`**: The URL to your `geoplatform` instance (without trailing slash). **ex:** `https://geo.data.gouv.fr`

--- a/udata_geoplatform/preview.py
+++ b/udata_geoplatform/preview.py
@@ -1,16 +1,26 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from flask import current_app
 from udata.i18n import get_locale
 from udata.core.dataset.preview import PreviewPlugin
+
+from . import settings as DEFAULTS
 
 GEOP_PREFIX = 'geop'
 RESOURCE_EXTRA = '{}:resource_id'.format(GEOP_PREFIX)
 DATASET_EXTRA = '{}:dataset_id'.format(GEOP_PREFIX)
-GEOP_URL_TEMPLATE = 'https://geo.data.gouv.fr/embed/datasets/{dataset_id}/resources/{resource_id}?lang={lang}'  # noqa
+GEOP_URL_TEMPLATE = '{geoplatform_url}/embed/datasets/{dataset_id}/resources/{resource_id}?lang={lang}'  # noqa
 
 
 class GeoplatformPreview(PreviewPlugin):
+    @property
+    def geoplatform_url(self):
+        return current_app.config.get(
+            'GEOPLATFORM_URL',
+            DEFAULTS.GEOPLATFORM_URL
+        )
+
     def get_resource_extra(self, resource):
         return getattr(resource, 'extras', {}).get(RESOURCE_EXTRA)
 
@@ -23,6 +33,7 @@ class GeoplatformPreview(PreviewPlugin):
 
     def preview_url(self, resource):
         return GEOP_URL_TEMPLATE.format(
+            geoplatform_url=self.geoplatform_url,
             resource_id=self.get_resource_extra(resource),
             dataset_id=self.get_dataset_extra(resource),
             lang=get_locale(),

--- a/udata_geoplatform/settings.py
+++ b/udata_geoplatform/settings.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+'''
+Default settings for udata-geoplatform
+'''
+# geoplatform instance URL
+GEOPLATFORM_URL = 'https://geo.data.gouv.fr'


### PR DESCRIPTION
Not sure about how to handle defaults. I guess I could set the defaults [beforehand like in `udata-tabular-preview`](https://github.com/opendatateam/udata-tabular-preview/blob/65b50689901ea9cb2e3e6f3d961135fdbf91bacd/udata_tabular_preview/views.py#L34-L35) but I am not sure where in this plugin. :)

Fix #9 
